### PR TITLE
Include warmups

### DIFF
--- a/src/maudit/main.py
+++ b/src/maudit/main.py
@@ -31,11 +31,17 @@ def main(path_to_output_dir: Path):
     infd_dict = return_dict_of_infd(csvs, mi)
     lp_pd = return_pd_var(infd_dict, "lp")
     step_size_pd = return_pd_var(infd_dict, "step_size")
+    lp_pd_w = return_pd_var(infd_dict, "lp", True)
+    step_size_pd_w = return_pd_var(infd_dict, "step_size", True)
 
     lp_plot = plot_var_time_series(lp_pd, "lp")
     lp_plot.save(filename = 'lp_time_series.png')
     step_size_plot = plot_var_time_series(step_size_pd, "step_size")
     step_size_plot.save(filename = 'step_size_time_series.png')
+    lp_plot_w = plot_var_time_series(lp_pd_w, "lp")
+    lp_plot_w.save(filename = 'lp_time_series_warmup.png')
+    step_size_plot_w = plot_var_time_series(step_size_pd_w, "step_size")
+    step_size_plot_w.save(filename = 'step_size_time_series_warmup.png')
 
 
 if __name__ == "__main__":

--- a/src/maudit/utils.py
+++ b/src/maudit/utils.py
@@ -17,13 +17,18 @@ def return_dict_of_infd(csvs, mi):
         for chain in csvs
         }
 
-def return_pd_var(infd_dict: dict(), var_name: str()):
+def return_pd_var(infd_dict: dict(), var_name: str(), WARMUP_TAG: bool() = False):
     """Returns a df of sample stat variable.
     :params infd_dict: a dictionary of infd objects
     :params var_name: a string indicating the variable of interest
+    :params WARMUP_TAG: indicator of if warmup draws are of interest
     """
+    if WARMUP_TAG is True:
+        sample_stats = "warmup_sample_stats"
+    else:
+        sample_stats = "sample_stats"
     var_dict = {
-            chain: idata.sample_stats[var_name].to_series()
+            chain: idata[sample_stats][var_name].to_series()
             for chain, idata in infd_dict.items()
         }
     var_df = pd.DataFrame(var_dict).droplevel('chain').rename_axis('chain', axis='columns').stack().rename(var_name).reset_index()


### PR DESCRIPTION
# Summary
To access the warmup sample stats in the infd we need to prefix the field with "warmup_". We now plot the lp and step_size for the warmup draws as well.

There may be a cleaner way to write this code and I would like to know if there is